### PR TITLE
Remove dayCellContent hook and add class in eventContent hook instead

### DIFF
--- a/src/components/calendarpage.jsx
+++ b/src/components/calendarpage.jsx
@@ -139,29 +139,17 @@ export function CalendarPage() {
     periodTracker.createPeriodEntry(periodEntryData);
   }
 
-  const DayCell = ({ info }) => {
-    // Check if date overlaps with a period
-    for (let i = 0; i < periods.length; i++) {
-      const period = periods[i];
-      const dayCellDate = info.date;
-      const startDate = stringToDate(period.startDate);
-      const endDate = stringToDate(period.endDate);
-      if (dayCellDate >= startDate && dayCellDate <= endDate) {
-        return (<div></div>);
-      }
-    }
-    return (
-      <div>
-        {info.dayNumberText}
-      </div>
-    );
-  }
-
   const EventItem = ({ info }) => {
     const { event } = info;
     const flowType = event.extendedProps.flowType;
     const date = toUTCDate(event.start);
     const day = date.getDate();
+
+    // Update the daycell
+    const dateString  = formatDate(date);
+    const tdElement = document.querySelector(`td[data-date="${dateString}"]`);
+    tdElement.classList.add('day-with-event');
+
     // The timestamp on the event is 00:00 GMT but in PST, so it's the previous day. 
     // Convert it to the GMT date.
     return (
@@ -226,7 +214,6 @@ export function CalendarPage() {
         eventClick={openModalFromCalendar} // TODO: Fix existing modal to support editing period data or display a different modal
         eventContent={(info) => <EventItem info={info} />}
         initialView="dayGridMonth"
-        dayCellContent={(info) => <DayCell info={info} />}
         events={events}
         aspectRatio={1}
       />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -57,6 +57,21 @@ h1, h2, h3, h4, h5, h6 {
   justify-content: center;
 }
 
+.day-with-event {
+  /* Do not display the day cell date*/
+  .fc-daygrid-day-top {
+    display: none;
+  }
+
+  .fc-daygrid-day-frame {
+    display: flex;
+    /* horizontally center the dot */
+    justify-content: center;
+    /* vertically center the dot */
+    align-items: center;
+  }
+}
+
 .fc-h-event {
   background-color: transparent;
   border: none;


### PR DESCRIPTION
dayCellContent hook is only triggered when the calendar first loads, so when the user adds new period data the day cell date would still display:
![image](https://github.com/blackgirlbytes/LunaFocus/assets/12180288/3de3abc4-1511-4e2e-8e32-5fa73b9cbc04)

Remove usage of this hook and instead add a CSS class to the day cell in the eventContent hook. This CSS class effectively hides the day cell date in realtime


https://github.com/blackgirlbytes/LunaFocus/assets/12180288/67571710-381e-4f69-a065-bcd6863a9be5

